### PR TITLE
Adding a warning for developers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# These owners will be the default owners for everything in the repository.
-# Unless a later match takes precedence,
-# they will be requested for review when someone opens a pull request.
-*    @Jahia/cloud_contributor


### PR DESCRIPTION
Added a warning to ensure we don't modify the API methods without prior consultation with the Jahia Cloud team.