### PR TITLE
TECH-1630: Adjust org.json code compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
                             org.osgi.service.log,
                             org.osgi.service.repository,
                             org.osgi.util.tracker,
-                            org.json,
+                            org.json;version="[20070829, 20231014)"
                             com.fasterxml.jackson.databind,
                             com.fasterxml.jackson.databind.*,
                             org.slf4j,

--- a/src/main/java/org/jahia/modules/elasticsearchconnector/connection/ElasticSearchConnectionRegistry.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/connection/ElasticSearchConnectionRegistry.java
@@ -227,7 +227,7 @@ public class ElasticSearchConnectionRegistry extends AbstractDatabaseConnectionR
         if (!jsonConnectionData.has("host") || StringUtils.isEmpty(jsonConnectionData.getString("host"))) {
             missingParameters.put("host");
         }
-        if (!missingParameters.isEmpty()) {
+        if (missingParameters.length() > 0) {
             result.put("connectionStatus", ESConstants.FAILED);
         } else {
             createConnectionFromJSON(result, jsonConnectionData);
@@ -238,9 +238,12 @@ public class ElasticSearchConnectionRegistry extends AbstractDatabaseConnectionR
     private void createConnectionFromJSON(Map<String, Object> result, JSONObject jsonConnectionData) throws JSONException {
         String id = jsonConnectionData.getString("id");
         String host = jsonConnectionData.getString("host");
-        Integer port = jsonConnectionData.optIntegerObject("port", null);
+        Integer port = null;
+        try {
+            port = jsonConnectionData.getInt("port");
+        } catch (JSONException e) { /* Do nothing; default to null */ }
         Boolean isConnected = jsonConnectionData.has(ESConstants.IS_CONNECTED) && jsonConnectionData.getBoolean(ESConstants.IS_CONNECTED);
-        String options = jsonConnectionData.has(ESConstants.OPTIONSKEY) ? jsonConnectionData.getJSONObject(ESConstants.OPTIONSKEY).toString() : null;
+        String options = jsonConnectionData.has(ESConstants.OPTIONSKEY) ? jsonConnectionData.get(ESConstants.OPTIONSKEY).toString() : null;
         String password = jsonConnectionData.has(ESConstants.CREDKEY) ? jsonConnectionData.getString(ESConstants.CREDKEY) : null;
         String user = jsonConnectionData.has("user") ? jsonConnectionData.getString("user") : null;
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1630

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Revert some of the code changes here https://github.com/Jahia/elasticsearch-connector/pull/30/files?w=1 to ensure compatibility on both 8.1.x and 8.2-SN

- Add compatibility range for org.json in pom.xml
- Refactor common code for creating ElasticSearchConnection object in ECApi
- Revert `JSONObject.isEmpty()` back to `JSONObject.length() > 0`
- add try-catch on parsing port property and default to null
- Retrieve options property with generic get 

