### PR TITLE
TECH-1416: Fix missing import-package dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,42 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.jahia.server</groupId>
+            <artifactId>jahia-impl</artifactId>
+            <version>8.1.6.1</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <version>${osgi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.7</version>
@@ -329,7 +365,6 @@
                             com.fasterxml.jackson.databind.*,
                             org.slf4j,
                             org.apache.commons.lang,
-                            com.google.common.collect,
                             org.apache.commons.logging,
                             org.apache.commons.logging.*,
                             javax.naming,

--- a/src/main/java/org/jahia/modules/elasticsearchconnector/connection/ElasticSearchConnection.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/connection/ElasticSearchConnection.java
@@ -23,7 +23,6 @@
  */
 package org.jahia.modules.elasticsearchconnector.connection;
 
-import com.google.common.collect.Iterables;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -388,7 +387,7 @@ public class ElasticSearchConnection extends AbstractConnection {
         }
         addresses.add(0, new HttpHost(host, port, protocolScheme));
 
-        RestClientBuilder builder = RestClient.builder(Iterables.toArray(addresses, HttpHost.class));
+        RestClientBuilder builder = RestClient.builder(addresses.toArray(new HttpHost[0]));
         builder.setRequestConfigCallback(
                 requestConfigBuilder -> requestConfigBuilder
                         .setConnectTimeout(30000)


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1416

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Refactor google guava references

We also had an issue with missing import-package `com.sun.activation.registries` which seems to be coming from javax.activation from jahia-impl. To fix, we declare `jahia-impl` as dependency and exclude everything except dependencies needed for compilation.