### PR TITLE
feat: Wait for node types definition to be synchronized on activation

### DIFF
--- a/src/main/java/org/jahia/modules/elasticsearchconnector/connection/ElasticSearchConnectionRegistry.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/connection/ElasticSearchConnectionRegistry.java
@@ -149,6 +149,7 @@ public class ElasticSearchConnectionRegistry extends AbstractDatabaseConnectionR
             try {
                 return query(session);
             } catch (NoSuchNodeTypeException e) {
+                retriesCount++;
                 logger.warn("Node type {} not available ({}), retrying in {} ms (attempt {}/{}) waiting for the cluster to synchronize the node types definition...", ElasticSearchConnection.NODE_TYPE, e.getMessage(), RETRY_INTERVAL_MS, retriesCount, MAX_RETRIES_COUNT);
                 try {
                     Thread.sleep(RETRY_INTERVAL_MS);
@@ -157,7 +158,6 @@ public class ElasticSearchConnectionRegistry extends AbstractDatabaseConnectionR
                     throw new RuntimeException("Thread was interrupted during retry sleep", ie);
                 }
             }
-            retriesCount++;
         }
         throw new RepositoryException("Failed to get node types after " + MAX_RETRIES_COUNT + " retries");
     }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
In a cluster environment, wait for the node type definition to be synchronized before querying the JCR with the node type `ec:elasticsearchConnection` added by the [`definitions.cnd`](https://github.com/Jahia/elasticsearch-connector/blob/master/src/main/resources/META-INF/definitions.cnd#L8) file.

On a non-processing servers, if a `NoSuchNodeTypeException` is thrown, wait one second before retrying and log the following message:
```
WARN  [ElasticSearchConnectionRegistry] - Node type ec:elasticsearchConnection not available (Unknown type : ec:elasticsearchConnection), retrying in 1000 ms (attempt 5/60) waiting for the cluster to synchronize the node types definition...
```

This is a workaround and a **temporary** solution to https://github.com/Jahia/jahia-private/issues/3394.

