### PR TITLE
fix: Set sniffer interval default to disabled

### DIFF
--- a/src/main/java/org/jahia/modules/elasticsearchconnector/ESConstants.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/ESConstants.java
@@ -18,6 +18,6 @@ public final class ESConstants {
     public static final boolean DEFAULT_USE_XPACK_SECURITY = false;
     public static final String DEFAULT_USE_ENCRYPTION_STR = "false";
     public static final boolean DEFAULT_USE_ENCRYPTION = false;
-    public static final String DEFAULT_SNIFFER_INTERVAL = "5s";
+    public static final String DEFAULT_SNIFFER_INTERVAL = "";
     public static final String DEFAULT_USER = "elastic";
 }

--- a/src/main/java/org/jahia/modules/elasticsearchconnector/config/ElasticsearchConfigMetatype.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/config/ElasticsearchConfigMetatype.java
@@ -53,7 +53,7 @@ public @interface ElasticsearchConfigMetatype {
 
     @AttributeDefinition(
             name = "Nodes Sniffer Interval",
-            description = "Interval for node sniffing (e.g., 5s)",
+            description = "Interval for node sniffing (e.g., 5s); Sniffer is disabled if set to empty string or invalid interval",
             defaultValue = DEFAULT_SNIFFER_INTERVAL
     )
     String elasticsearchConnector_snifferInterval() default DEFAULT_SNIFFER_INTERVAL;

--- a/src/main/java/org/jahia/modules/elasticsearchconnector/service/ElasticsearchClientWrapperImpl.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/service/ElasticsearchClientWrapperImpl.java
@@ -151,7 +151,7 @@ public class ElasticsearchClientWrapperImpl implements ElasticsearchClientWrappe
 
         // Create default sniff failure listener before building client
         SniffOnFailureListener sniffOnFailureListener = null;
-        if (!isTestClient && connectionConfig.getSnifferInterval() != null) {
+        if (!isTestClient && connectionConfig.getSnifferIntervalMillis() >= 0) {
             logger.debug("Initializing Sniffer configurations");
             sniffOnFailureListener = new SniffOnFailureListener();
             builder.setFailureListener(sniffOnFailureListener);
@@ -169,7 +169,7 @@ public class ElasticsearchClientWrapperImpl implements ElasticsearchClientWrappe
     }
 
     private void configureSniffer(Rest5Client restClient, SniffOnFailureListener sniffOnFailureListener, ElasticsearchConnectionConfig connConfig) {
-        if (connConfig.getSnifferInterval() == null || sniffOnFailureListener == null) {
+        if (connConfig.getSnifferIntervalMillis() < 0 || sniffOnFailureListener == null) {
             return;
         }
         ElasticsearchNodesSniffer.Scheme scheme = connConfig.isUseEncryption() ?


### PR DESCRIPTION
### Description

Set sniffer to be disabled by default (as it was in the [previous version](https://github.com/Jahia/elasticsearch-connector/blob/3_4_0/src/main/java/org/jahia/modules/elasticsearchconnector/connection/ElasticSearchConnection.java#L88)).

It is also best practice not to enable this for cloud-managed ES instance https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how