### PR TITLE
fix: Fix handling of null, empty values in sniffer interval

### DIFF
--- a/src/main/java/org/jahia/modules/elasticsearchconnector/config/ElasticsearchConnectionConfig.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/config/ElasticsearchConnectionConfig.java
@@ -102,6 +102,7 @@ public class ElasticsearchConnectionConfig {
         String interval = getSnifferInterval();
         if (interval == null || interval.isEmpty()) {
             this.snifferIntervalMillis = -1;
+            return;
         }
 
         // Extract number and unit using regex


### PR DESCRIPTION
### Description

Skip parsing of value if sniffer interval is null or empty as we set it to < 0.

