### PR TITLE
fix: Remove jackson export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,9 +202,6 @@
                             co.elastic.clients.json.*,
                             co.elastic.clients.util.*,
                             jakarta.json,
-                            <!-- Needed for resolving ES connection within graphql context-->
-                            com.fasterxml.jackson.annotation,
-                            com.fasterxml.jackson.databind,
                             org.jahia.modules.elasticsearchconnector,
                             org.jahia.modules.elasticsearchconnector.service
                         </Export-Package>


### PR DESCRIPTION
### Description

jackson package export is causing conflicts since we already have a jackson package provider in jahia that is different than what graphql is currently wired to.

In this case we use our own dependency version and resolve it internally. 

The export was initially added because of a `ClassCastException` that was happening when parsing JSON values within a graphql context eg. when querying `admin.elasticsearch.testConnection`. This doesn't seem to be happening anymore.
