### PR TITLE
fix: Update nexus plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <elasticsearch.version>9.1.3</elasticsearch.version>
         <jahia.nexus.staging.repository.id>40c27f27a86d2d</jahia.nexus.staging.repository.id>
         <jahia.plugin.version>6.13</jahia.plugin.version>
+        <nexus.maven.plugin.version>1.7.0</nexus.maven.plugin.version>
         <jahia-depends>graphql-dxm-provider</jahia-depends>
     </properties>
 


### PR DESCRIPTION
### Description

We currently get an [error](https://github.com/Jahia/elasticsearch-connector/issues/83#issuecomment-3503078891) when trying to do release on step `mvn release:perform`:

```
Error: [ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy (injected-nexus-deploy) on project elasticsearch-connector: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy: java.lang.ExceptionInInitializerError: null
...
Error: [ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
Error: [ERROR] 
Error: [ERROR] …
```

Update nexus plugin to make it compatible with JVM 17, similar to what was done in core: https://github.com/Jahia/jahia-private/pull/2371

