### PR TITLE
fix: custom TLS settings in development mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <artifactId>elasticsearch-connector</artifactId>
     <name>Elastic Search Connector</name>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is a custom module (ElasticSearch Connector) for running on a Jahia.</description>
 
@@ -46,7 +46,7 @@
 
     <properties>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MCwCFBe0BJ0CM48yZ4tChmFXBkFkW4ifAhRULmSVw3c57Ic2yd6AFXHbqc/H5A==</jahia-module-signature>
+        <jahia-module-signature>MCwCFAMVz0MVJ6/3yxkZ4VOaADW9OOyiAhQxa+BID5cohO4ADLocbhkL92FCjA==</jahia-module-signature>
         <elasticsearch.version>9.1.3</elasticsearch.version>
         <jahia.nexus.staging.repository.id>40c27f27a86d2d</jahia.nexus.staging.repository.id>
         <jahia.plugin.version>6.13</jahia.plugin.version>

--- a/src/main/java/org/jahia/modules/elasticsearchconnector/service/ConnectionUtils.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/service/ConnectionUtils.java
@@ -27,19 +27,15 @@ import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
-import org.apache.hc.core5.http.nio.ssl.BasicClientTlsStrategy;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
-import org.apache.hc.core5.net.NamedEndpoint;
 import org.apache.hc.core5.reactor.IOReactorConfig;
-import org.apache.hc.core5.reactor.ssl.SSLSessionVerifier;
-import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.jahia.modules.elasticsearchconnector.config.ConnectionConfigException;
 import org.jahia.modules.elasticsearchconnector.config.ElasticsearchConnectionConfig;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -104,14 +100,10 @@ public final class ConnectionUtils {
      * @return TlsStrategy that disables hostname verification
      */
     public static TlsStrategy getNoopHostnameStrategy(SSLContext sslContext) {
-        // SSLSessionVerifier that effectively disables hostname verification
-        SSLSessionVerifier noopVerifier = new SSLSessionVerifier() {
-            @Override
-            public TlsDetails verify(NamedEndpoint namedEndpoint, SSLEngine sslEngine) throws SSLException {
-                return new TlsDetails(sslEngine.getSession(), sslEngine.getSession().getProtocol());
-            }
-        };
-        return new BasicClientTlsStrategy(sslContext, noopVerifier);
+        return ClientTlsStrategyBuilder.create()
+                .setSslContext(sslContext)
+                .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                .buildAsync();
     }
 
     /**


### PR DESCRIPTION
### Description

Ran into some TLS issue in cloud when environment is in dev mode about unsupported protocols:

```
org.jahia.modules.augmentedsearch.ESNotConnectedException: Error during connection setup: Unsupported application protocol: TLSv1.3
	at org.jahia.modules.augmentedsearch.settings.ESSettingsService.getElasticsearchClientWrapper(ESSettingsService.java:331) ~[?:?]
	at org.jahia.modules.augmentedsearch.settings.ESSettingsService.getClient(ESSettingsService.java:317) ~[?:?]
	at org.jahia.modules.augmentedsearch.settings.ESSettingsService.getPlugins(ESSettingsService.java:151) ~[?:?]
	at org.jahia.modules.augmentedsearch.graphql.extensions.query.ASAdminQueries.getDbConnections(ASAdminQueries.java:79) ~[?:?]
	... suppressed 2 lines
```

Issue is coming from our custom TLS setting to disable hostname verification that's only used in dev mode.

Use available `ClientTlsStrategyBuilder` to disable hostname verification in dev mode but keep it as default as possible.  

Update to patch version 4.0.1

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [x] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
