### PR TITLE
fix: add preemptive auth header to avoid double requests

### DIFF
--- a/.chachalog/v3_gS868.md
+++ b/.chachalog/v3_gS868.md
@@ -1,0 +1,5 @@
+---
+# Allowed version bumps: patch, minor, major
+elasticsearch-connector: patch
+---
+Fixed an authentication strategy regression.

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -58,10 +58,10 @@ jobs:
 
   integration-tests-standalone:
     uses:  Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
-    needs: build   
+    needs: build
     secrets: inherit
     with:
-      jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       module_id: elasticsearch-connector
       testrail_project: Elasticsearch connector
       pagerduty_skip_notification: true

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -52,10 +52,10 @@ jobs:
 
   integration-tests-standalone:
     uses:  Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
-    needs: build   
+    needs: build
     secrets: inherit
     with:
-      jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       module_id: elasticsearch-connector
       testrail_project: Elasticsearch connector
       pagerduty_skip_notification: true

--- a/src/main/java/org/jahia/modules/elasticsearchconnector/service/ConnectionUtils.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/service/ConnectionUtils.java
@@ -23,13 +23,11 @@
  */
 package org.jahia.modules.elasticsearchconnector.service;
 
-import org.apache.hc.client5.http.auth.AuthScope;
-import org.apache.hc.client5.http.auth.CredentialsProvider;
-import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
-import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.reactor.IOReactorConfig;
 import org.jahia.modules.elasticsearchconnector.config.ConnectionConfigException;
@@ -38,7 +36,9 @@ import org.jahia.modules.elasticsearchconnector.config.ElasticsearchConnectionCo
 import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -50,16 +50,12 @@ public final class ConnectionUtils {
     }
 
     /**
-     * @return {@code CredentialsProvider} that includes username, password credentials
-     * from the ES connection config and uses host:port as scope for applicable auth requests.
+     * @return Preemptive Basic Authorization headers built from the ES connection config credentials.
      */
-    public static CredentialsProvider getCredentialsProvider(ElasticsearchConnectionConfig connConfig) throws ConnectionConfigException {
-        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        credentialsProvider.setCredentials(
-                new AuthScope(null, -1), // Matches ANY host and port. Giving specific ones leads to eventual loss of connection
-                new UsernamePasswordCredentials(connConfig.getUser(), connConfig.decodePassword())
-        );
-        return credentialsProvider;
+    public static Header[] getAuthHeaders(ElasticsearchConnectionConfig connConfig) throws ConnectionConfigException {
+        String credentials = connConfig.getUser() + ":" + new String(connConfig.decodePassword());
+        String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return new Header[]{ new BasicHeader("Authorization", "Basic " + encoded) };
     }
 
     /**

--- a/src/main/java/org/jahia/modules/elasticsearchconnector/service/ElasticsearchClientWrapperImpl.java
+++ b/src/main/java/org/jahia/modules/elasticsearchconnector/service/ElasticsearchClientWrapperImpl.java
@@ -10,7 +10,6 @@ import co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder;
 import co.elastic.clients.transport.rest5_client.low_level.sniffer.ElasticsearchNodesSniffer;
 import co.elastic.clients.transport.rest5_client.low_level.sniffer.SniffOnFailureListener;
 import co.elastic.clients.transport.rest5_client.low_level.sniffer.Sniffer;
-import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -196,12 +195,10 @@ public class ElasticsearchClientWrapperImpl implements ElasticsearchClientWrappe
             sslContext = SSLContexts.custom().loadTrustMaterial(sslTrustStrategy).build();
             restClientBuilder.setSSLContext(sslContext);
 
-            // Provide credentials, tcpip request config to client config callback
-            final CredentialsProvider credentialsProvider = ConnectionUtils.getCredentialsProvider(connConfig);
+            // Set preemptive auth headers to avoid 401 → retry on every request
+            restClientBuilder.setDefaultHeaders(ConnectionUtils.getAuthHeaders(connConfig));
             restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> {
-                httpClientBuilder
-                        .setDefaultCredentialsProvider(credentialsProvider)
-                        .setIOReactorConfig(reactorConfig);
+                httpClientBuilder.setIOReactorConfig(reactorConfig);
             });
 
             // Disable hostname verification in dev mode


### PR DESCRIPTION
### Description
This PR fixes an issue in ES connector that causes every single ES request to happen twice. This bug was introduced in 5d182d0.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
